### PR TITLE
Fix Redis protocol implementation so it supports CLIENT command

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,17 @@
+FROM amd64/debian:bullseye
+
+RUN apt-get update
+RUN apt-get -y install wget libjpeg-dev automake libtool autoconf zlib1g-dev libxml2 libxmlsec1-dev libc-dev libffi-dev gcc g++ pkg-config make
+
+COPY . /usr/src/twemproxy
+RUN mkdir /etc/config/
+COPY ./nutcracker.yaml /etc/config/
+WORKDIR /usr/src/twemproxy
+
+RUN autoreconf -h
+RUN autoreconf -fvi
+RUN CFLAGS="-O3 -fno-strict-aliasing" && ./configure --enable-debug=full
+RUN CFLAGS="-O3 -fno-strict-aliasing" && make
+RUN CFLAGS="-O3 -fno-strict-aliasing" && make install
+
+ENTRYPOINT [ "nutcracker", "-c", "/etc/config/nutcracker.yaml" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+---
+version: "3.9"
+services:
+  nutcracker:
+    platform: linux/amd64
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    build:
+      dockerfile: Dockerfile-dev
+    restart: unless-stopped
+    ports:
+      - 6380:6380
+
+  redis:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    image: redis:7.2
+    ports:
+      - "6379:6379"

--- a/nutcracker.yaml
+++ b/nutcracker.yaml
@@ -1,0 +1,11 @@
+redis:
+  listen: 0.0.0.0:6380
+  hash: fnv1a_64
+  distribution: ketama
+  auto_eject_hosts: true
+  redis: true
+  timeout: 400
+  server_retry_timeout: 2000
+  server_failure_limit: 1
+  servers:
+    - host.docker.internal:6379:1

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -201,6 +201,7 @@ typedef enum msg_parse_result {
     ACTION( REQ_REDIS_AUTH)                                                                         \
     ACTION( REQ_REDIS_SELECT)                  /* only during init */                               \
     ACTION( REQ_REDIS_COMMAND)                 /* Sent to random server for redis-cli completions*/ \
+    ACTION( REQ_REDIS_CLIENT )                 /* Sent to random server for redis-cli completions*/ \
     ACTION( REQ_REDIS_LOLWUT)                  /* Vitally important */                              \
     ACTION( RSP_REDIS_STATUS )                 /* redis response */                                 \
     ACTION( RSP_REDIS_ERROR )                                                                       \

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -166,6 +166,8 @@ redis_arg2(const struct msg *r)
 
     case MSG_REQ_REDIS_SMOVE:
 
+    case MSG_REQ_REDIS_CLIENT:
+
     case MSG_REQ_REDIS_ZCOUNT:
     case MSG_REQ_REDIS_ZLEXCOUNT:
     case MSG_REQ_REDIS_ZINCRBY:
@@ -998,6 +1000,10 @@ redis_parse_req(struct msg *r)
 
                 if (str6icmp(m, 'u', 'n', 'l', 'i', 'n', 'k')) {
                     r->type = MSG_REQ_REDIS_UNLINK;
+                    break;
+                }
+                if (str6icmp(m, 'c', 'l', 'i', 'e', 'n', 't')) {
+                    r->type = MSG_REQ_REDIS_CLIENT;
                     break;
                 }
 


### PR DESCRIPTION
Current implementation of Redis protocol's parser doesn't support CLIENT command.
Which means that if the new redis-py library is used it fails to proxy any commands. The reason for that is `redis-py` (5.0.1 version) sends `CLIENT SETNAME <name of the connectio>` command on connect (before making the first call to the redis)